### PR TITLE
Fix length_mask2 broadcast bug

### DIFF
--- a/puzzle_board/puzzle_board_detector.py
+++ b/puzzle_board/puzzle_board_detector.py
@@ -175,7 +175,7 @@ def detect_puzzleboard(img):
                 neighbor_idx[i,1] = nearest_orthogonal
 
                 opp_orth_mask = (np.sum(nvecs*nvecs[pos,:].T,axis=1) < -thr3)
-                length_mask2 = (np.maximum(lens / lens[pos], lens[pos] / lens) <= 1.5)
+                length_mask2 = (np.maximum(lens / lens[pos], lens[pos] / lens) <= 1.5).flatten()
                 nearest_opp_orth = np.sum(np.cumprod(1 - neighb_mask[i,:] * opp_orth_mask * length_mask2))
                 if(nearest_opp_orth<NUMBER_WANTED_NEIGHBORS):
                     nb2o = idx_neighbors[i,nearest_opp_orth]   # index of nearest opposite orth neighbor with appropriate orientation


### PR DESCRIPTION
`length_mask2` is a (10, 1) matrix and when multiplied to create `nearest_opp_orth` it turns into a (10, 10) matrix. I'm assuming this is unintentional, correct me if I'm wrong or if I'm missing something.